### PR TITLE
Adds manual triple insertion through (internal) stream support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ exampleJsApp/node_modules
 exampleJsApp/packages_imported
 exampleJsApp/package-lock.json
 kotlin-js-store/yarn.lock
+shared/src/jsMain/js/lib/

--- a/exampleJsApp/index.ts
+++ b/exampleJsApp/index.ts
@@ -1,4 +1,49 @@
 import { LDESTS, Shape } from "ldests";
+import { Quad, DataFactory } from "n3";
+const { namedNode, literal } = DataFactory;
+
+async function * generateRandomData(limit: number) {
+    var i = 0
+    const properties = [
+        "https://dahcc.idlab.ugent.be/Ontology/SensorsAndWearables/SmartphoneAcceleration/x",
+        "https://dahcc.idlab.ugent.be/Ontology/SensorsAndWearables/SmartphoneAcceleration/y",
+        "https://dahcc.idlab.ugent.be/Ontology/SensorsAndWearables/SmartphoneAcceleration/z"
+    ];
+    while (i < limit) {
+        yield new Quad(
+            namedNode(`http://example.com/obs${i}`),
+            namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+            namedNode("https://saref.etsi.org/core/Measurement")
+        );
+        yield new Quad(
+            namedNode(`http://example.com/obs${i}`),
+            namedNode("https://saref.etsi.org/core/hasValue"),
+            literal(i)
+        );
+        yield new Quad(
+            namedNode(`http://example.com/obs${i}`),
+            namedNode("https://saref.etsi.org/core/hasTimestamp"),
+            literal(new Date().toISOString())
+        );
+        yield new Quad(
+            namedNode(`http://example.com/obs${i}`),
+            namedNode("https://saref.etsi.org/core/relatesToProperty"),
+            namedNode(properties[Math.floor(Math.random() * properties.length)])
+        );
+        yield new Quad(
+            namedNode(`http://example.com/obs${i}`),
+            namedNode("https://saref.etsi.org/core/measurementMadeBy"),
+            namedNode("https://dahcc.idlab.ugent.be/Ontology/SensorsAndWearables/Smartphone/RNG")
+        );
+        yield new Quad(
+            namedNode(`http://example.com/obs${i}`),
+            namedNode("http://rdfs.org/ns/void#inDataset"),
+            namedNode("https://dahcc.idlab.ugent.be/Protego/_participant1")
+        );
+        ++i;
+        await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+}
 
 // creating a shape with properties
 // constant("rdfs:inDataset", "protego:_participant1")
@@ -13,7 +58,7 @@ const shape = new Shape.Builder("https://saref.etsi.org/core/Measurement", "http
     ).constant(
         "https://saref.etsi.org/core/measurementMadeBy", [
             "https://dahcc.idlab.ugent.be/Ontology/SensorsAndWearables/Smartphone/OnePlus_IN2023",
-            "https://dahcc.idlab.ugent.be/Ontology/SensorsAndWearables/Smartphone/Samsung_S10",
+            "https://dahcc.idlab.ugent.be/Ontology/SensorsAndWearables/Smartphone/RNG",
         ]
     ).constant(
         "https://saref.etsi.org/core/relatesToProperty", [
@@ -35,6 +80,10 @@ async function main() {
 //         .attachDebugPublisher()
         .create();
     // await stream.append("../DAHCC-Data/dataset_participant_sample_accel_data.nt");
+    for await (const triple of generateRandomData(10)) {
+        stream.insert(triple);
+    }
+    await stream.flush();
     await stream.query(
         "http://localhost:3000",
         (triple) => console.log(`Got object ${triple.object.value}`),
@@ -45,7 +94,6 @@ async function main() {
         946718829400,
         946718829900
     );
-    await stream.flush();
     await stream.close();
     console.log("Finished main");
 }

--- a/jsLibrary/build.gradle.kts
+++ b/jsLibrary/build.gradle.kts
@@ -19,16 +19,17 @@ plugins {
 afterEvaluate {
     // task to copy the resulting generated code to the example app's modules
     val updateExampleApp = tasks.create("updateExampleApp", Copy::class.java) {
-        from("../build/js/packages")
-        into("../exampleJsApp/node_modules")
+        doFirst { mkdir("../exampleJsApp/node_modules/ldests") }
+        from("../build/js/packages/ldests")
+        into("../exampleJsApp/node_modules/ldests")
     }
     // task to update the exampleJsApp with this base code
-    val updateExampleAppBaseTask = tasks.create("updateExampleAppBaseTask", Copy::class.java) {
-        doFirst { mkdir("../exampleJsApp/node_modules/base") }
+    val updateExampleAppCompat = tasks.create("updateExampleAppCompat", Copy::class.java) {
+        doFirst { mkdir("../exampleJsApp/node_modules/ldests/node_modules/ldests_compat") }
         from("../shared/src/jsMain/js")
-        into("../exampleJsApp/node_modules/base")
+        into("../exampleJsApp/node_modules/ldests/node_modules/ldests_compat")
     }
-    updateExampleApp.finalizedBy(updateExampleAppBaseTask)
+    updateExampleApp.finalizedBy(updateExampleAppCompat)
     // task to test the library by running the `exampleJsApp`
     val testLibraryTask = tasks.create("testLibraryTask", Exec::class.java) {
         workingDir = File("..")

--- a/jsLibrary/build.gradle.kts
+++ b/jsLibrary/build.gradle.kts
@@ -25,22 +25,10 @@ afterEvaluate {
     // task to update the exampleJsApp with this base code
     val updateExampleAppBaseTask = tasks.create("updateExampleAppBaseTask", Copy::class.java) {
         doFirst { mkdir("../exampleJsApp/node_modules/base") }
-        from("../shared/src/jsMain/js/src")
+        from("../shared/src/jsMain/js")
         into("../exampleJsApp/node_modules/base")
     }
     updateExampleApp.finalizedBy(updateExampleAppBaseTask)
-    // add the extra non-npm dependencies to the library
-    val addIncremunicaEngineToTest = tasks.create("addIncremunicaEngineToTest", Copy::class.java) {
-        doFirst { mkdir("../exampleJsApp/node_modules/@comunica/query-sparql-incremental") }
-        from("../shared/src/jsMain/build/incremunica/engines/query-sparql-incremental")
-        into("../exampleJsApp/node_modules/@comunica/query-sparql-incremental")
-    }
-    val addIncremunicaStreamToTest = tasks.create("addIncremunicaStreamToTest", Copy::class.java) {
-        doFirst { mkdir("../exampleJsApp/node_modules/@comunica/incremental-rdf-streaming-store") }
-        from("../shared/src/jsMain/build/incremunica/packages/incremental-rdf-streaming-store")
-        into("../exampleJsApp/node_modules/@comunica/incremental-rdf-streaming-store")
-    }
-    updateExampleApp.finalizedBy(addIncremunicaEngineToTest, addIncremunicaStreamToTest)
     // task to test the library by running the `exampleJsApp`
     val testLibraryTask = tasks.create("testLibraryTask", Exec::class.java) {
         workingDir = File("..")

--- a/jsLibrary/build.gradle.kts
+++ b/jsLibrary/build.gradle.kts
@@ -29,6 +29,18 @@ afterEvaluate {
         into("../exampleJsApp/node_modules/base")
     }
     updateExampleApp.finalizedBy(updateExampleAppBaseTask)
+    // add the extra non-npm dependencies to the library
+    val addIncremunicaEngineToTest = tasks.create("addIncremunicaEngineToTest", Copy::class.java) {
+        doFirst { mkdir("../exampleJsApp/node_modules/@comunica/query-sparql-incremental") }
+        from("../shared/src/jsMain/build/incremunica/engines/query-sparql-incremental")
+        into("../exampleJsApp/node_modules/@comunica/query-sparql-incremental")
+    }
+    val addIncremunicaStreamToTest = tasks.create("addIncremunicaStreamToTest", Copy::class.java) {
+        doFirst { mkdir("../exampleJsApp/node_modules/@comunica/incremental-rdf-streaming-store") }
+        from("../shared/src/jsMain/build/incremunica/packages/incremental-rdf-streaming-store")
+        into("../exampleJsApp/node_modules/@comunica/incremental-rdf-streaming-store")
+    }
+    updateExampleApp.finalizedBy(addIncremunicaEngineToTest, addIncremunicaStreamToTest)
     // task to test the library by running the `exampleJsApp`
     val testLibraryTask = tasks.create("testLibraryTask", Exec::class.java) {
         workingDir = File("..")

--- a/jsLibrary/src/jsMain/kotlin/LDESTS.kt
+++ b/jsLibrary/src/jsMain/kotlin/LDESTS.kt
@@ -1,6 +1,5 @@
 
 import be.ugent.idlab.predict.ldests.core.LDESTS
-import be.ugent.idlab.predict.ldests.core.MemoryPublisher
 import be.ugent.idlab.predict.ldests.core.Stream
 import be.ugent.idlab.predict.ldests.lib.rdf.N3Store
 import be.ugent.idlab.predict.ldests.lib.rdf.N3Triple
@@ -34,15 +33,6 @@ class LDESTSJS private constructor(
     fun close() = promise { parent.close() }
 
     @ExternalUse
-    fun toStore() = promise {
-        // flushing first, so the store is usable
-        parent.flush()
-        // looking for a memory based publisher
-        (parent.publishers.find { it is MemoryPublisher } as? MemoryPublisher)
-            ?.buffer?.store
-    }
-
-    @ExternalUse
     fun queryAsStore(
         url: String,
         constraints: dynamic,
@@ -72,6 +62,11 @@ class LDESTSJS private constructor(
             constraints = parseConstraints(constraints),
             range = start.toLong() until end.toLong()
         ).collect(callback)
+    }
+
+    @ExternalUse
+    fun insert(data: N3Triple) {
+        parent.insert(data)
     }
 
     /** Helper methods **/

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.incremental.createDirectory
 
 plugins {
     kotlin("multiplatform")
@@ -33,8 +34,8 @@ kotlin {
             dependencies {
                 implementation(npm("@comunica/query-sparql", "2.6.9"))
                 implementation(npm("n3", "1.16.4"))
-                val util = projectDir.resolve("src/jsMain/js/build/base-1.0.0.tgz").canonicalFile
-                implementation(npm("base", "file:$util"))
+                val util = projectDir.resolve("src/jsMain/js/build/ldests_compat-1.0.0.tgz").canonicalFile
+                implementation(npm("ldests_compat", "file:$util"))
             }
         }
 
@@ -43,49 +44,26 @@ kotlin {
 
 afterEvaluate {
     // task to build the JS base code
-    val buildBaseUtilTask = tasks.create("buildBaseUtilTask", Exec::class.java) {
-        workingDir = File("src/jsMain/js/src")
-        commandLine = listOf("npm", "pack", "--pack-destination", "../build")
+    val buildJsCompatTask = tasks.create("buildJsCompatTask", Exec::class.java) {
+        workingDir = File("src/jsMain/js")
+        commandLine = listOf("npm", "pack", "--pack-destination", "./build")
         doFirst { mkdir("${workingDir.parent}/build") }
     }
-    project.tasks.getByName("build").dependsOn(buildBaseUtilTask)
+    project.tasks.getByName("compileKotlinJs").dependsOn(buildJsCompatTask)
     // task to integrate incremunica
-    // TODO: adapt locations, maybe symlink for test lib task instead of copying
-//    val configureIncremunicaEngine = tasks.create("configureIncremunicaEngine", Exec::class.java) {
-//        val build = File("${workingDir.absolutePath}/" + File("src/jsMain/build"))
-//        if (!File("$build/incremunica/").exists()) {
-//            exec {
-//                workingDir = build
-//                workingDir.createDirectory()
-//                commandLine("git", "clone", "https://github.com/maartyman/incremunica.git")
-//            }
-//            exec {
-//                workingDir = File("$build/incremunica")
-//                commandLine("yarn", "install")
-//            }
-//        }
-//        workingDir = File("$build/incremunica/engines/query-sparql-incremental")
-//        commandLine("npm", "pack", "--pack-destination", build)
-//    }
-//    project.tasks.getByName("build").dependsOn(configureIncremunicaEngine)
-//    val configureIncremunicaStreamingStore = tasks.create("configureIncremunicaStreamingStore", Exec::class.java) {
-//        val build = File("${workingDir.absolutePath}/" + File("src/jsMain/build"))
-//        if (!File("$build/incremunica/").exists()) {
-//            exec {
-//                workingDir = build
-//                workingDir.createDirectory()
-//                commandLine("git", "clone", "https://github.com/maartyman/incremunica.git")
-//            }
-//            exec {
-//                workingDir = File("$build/incremunica")
-//                commandLine("yarn", "install")
-//            }
-//        }
-//        workingDir = File("$build/incremunica/packages/incremental-rdf-streaming-store")
-//        commandLine("npm", "pack", "--pack-destination", build)
-//    }
-//    project.tasks.getByName("build").dependsOn(configureIncremunicaEngine)
-//    project.tasks.getByName("build").dependsOn(configureIncremunicaStreamingStore)
+    val configureIncremunicaEngine = tasks.create("configureIncremunicaEngine", Exec::class.java) {
+        val lib = File("${workingDir.absolutePath}/" + File("src/jsMain/js/lib"))
+        if (!File("$lib/incremunica/").exists()) {
+            buildJsCompatTask.dependsOn(this)
+            exec {
+                workingDir = lib
+                workingDir.createDirectory()
+                commandLine("git", "clone", "https://github.com/maartyman/incremunica.git")
+            }
+        }
+        workingDir = File("$lib/incremunica")
+        commandLine("yarn", "install")
+    }
 }
 
 // Use a proper version of webpack, TODO remove after updating to Kotlin 1.9.

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.incremental.createDirectory
 
 plugins {
     kotlin("multiplatform")
@@ -34,16 +33,8 @@ kotlin {
             dependencies {
                 implementation(npm("@comunica/query-sparql", "2.6.9"))
                 implementation(npm("n3", "1.16.4"))
-
                 val util = projectDir.resolve("src/jsMain/js/build/base-1.0.0.tgz").canonicalFile
                 implementation(npm("base", "file:$util"))
-
-                val incremunica = projectDir.resolve("src/jsMain/build/comunica-query-sparql-incremental-1.0.0.tgz").canonicalFile
-                implementation(npm("@comunica/query-sparql-incremental", "file:$incremunica"))
-
-                val streamingStore = projectDir.resolve("src/jsMain/build/comunica-incremental-rdf-streaming-store-1.0.0.tgz").canonicalFile
-                implementation(npm("@comunica/incremental-rdf-streaming-store", "file:$streamingStore"))
-
             }
         }
 
@@ -59,41 +50,42 @@ afterEvaluate {
     }
     project.tasks.getByName("build").dependsOn(buildBaseUtilTask)
     // task to integrate incremunica
-    val configureIncremunicaEngine = tasks.create("configureIncremunicaEngine", Exec::class.java) {
-        val build = File("${workingDir.absolutePath}/" + File("src/jsMain/build"))
-        if (!File("$build/incremunica/").exists()) {
-            exec {
-                workingDir = build
-                workingDir.createDirectory()
-                commandLine("git", "clone", "https://github.com/maartyman/incremunica.git")
-            }
-            exec {
-                workingDir = File("$build/incremunica")
-                commandLine("yarn", "install")
-            }
-        }
-        workingDir = File("$build/incremunica/engines/query-sparql-incremental")
-        commandLine("npm", "pack", "--pack-destination", build)
-    }
-    project.tasks.getByName("build").dependsOn(configureIncremunicaEngine)
-    val configureIncremunicaStreamingStore = tasks.create("configureIncremunicaStreamingStore", Exec::class.java) {
-        val build = File("${workingDir.absolutePath}/" + File("src/jsMain/build"))
-        if (!File("$build/incremunica/").exists()) {
-            exec {
-                workingDir = build
-                workingDir.createDirectory()
-                commandLine("git", "clone", "https://github.com/maartyman/incremunica.git")
-            }
-            exec {
-                workingDir = File("$build/incremunica")
-                commandLine("yarn", "install")
-            }
-        }
-        workingDir = File("$build/incremunica/packages/incremental-rdf-streaming-store")
-        commandLine("npm", "pack", "--pack-destination", build)
-    }
-    project.tasks.getByName("build").dependsOn(configureIncremunicaEngine)
-    project.tasks.getByName("build").dependsOn(configureIncremunicaStreamingStore)
+    // TODO: adapt locations, maybe symlink for test lib task instead of copying
+//    val configureIncremunicaEngine = tasks.create("configureIncremunicaEngine", Exec::class.java) {
+//        val build = File("${workingDir.absolutePath}/" + File("src/jsMain/build"))
+//        if (!File("$build/incremunica/").exists()) {
+//            exec {
+//                workingDir = build
+//                workingDir.createDirectory()
+//                commandLine("git", "clone", "https://github.com/maartyman/incremunica.git")
+//            }
+//            exec {
+//                workingDir = File("$build/incremunica")
+//                commandLine("yarn", "install")
+//            }
+//        }
+//        workingDir = File("$build/incremunica/engines/query-sparql-incremental")
+//        commandLine("npm", "pack", "--pack-destination", build)
+//    }
+//    project.tasks.getByName("build").dependsOn(configureIncremunicaEngine)
+//    val configureIncremunicaStreamingStore = tasks.create("configureIncremunicaStreamingStore", Exec::class.java) {
+//        val build = File("${workingDir.absolutePath}/" + File("src/jsMain/build"))
+//        if (!File("$build/incremunica/").exists()) {
+//            exec {
+//                workingDir = build
+//                workingDir.createDirectory()
+//                commandLine("git", "clone", "https://github.com/maartyman/incremunica.git")
+//            }
+//            exec {
+//                workingDir = File("$build/incremunica")
+//                commandLine("yarn", "install")
+//            }
+//        }
+//        workingDir = File("$build/incremunica/packages/incremental-rdf-streaming-store")
+//        commandLine("npm", "pack", "--pack-destination", build)
+//    }
+//    project.tasks.getByName("build").dependsOn(configureIncremunicaEngine)
+//    project.tasks.getByName("build").dependsOn(configureIncremunicaStreamingStore)
 }
 
 // Use a proper version of webpack, TODO remove after updating to Kotlin 1.9.

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Shape.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Shape.kt
@@ -98,6 +98,8 @@ class Shape private constructor(
 
         }
 
+        abstract fun encode(data: Term): String
+
         abstract fun decode(data: List<String>): List<Term>
 
     }
@@ -105,6 +107,15 @@ class Shape private constructor(
     // TODO: split the two constant cases up
     // TODO: make the non-binding a different property type
     class ConstantProperty: Property {
+        /**
+         * TODO: migrate back to a query which looks like ([] already included)
+         * ```
+         * [?subject <predicate>] ?cv{id} .
+         * BIND(
+         *      IF(?cv{id} = value[0], 0, IF(?cv{id} = value[1], 1, ..., -1)) AS ?c{id}
+         * )
+         * ```
+         */
 
         /* NamedNodeTerm, BlankNodeTerm and LiteralTerm possible, but Literal's shouldn't be used */
         internal val values: List<Term>
@@ -121,22 +132,7 @@ class Shape private constructor(
             require(values.size > 1)
             this.values = values
             this.id = id
-            // creating the query
-            var filter = "BIND("
-            this.values.forEachIndexed { index, term ->
-                val statement = "?cv${id} = <${term.value}>, $index"
-                filter = "${filter}IF($statement, "
-            }
-            /**
-             * The resulting query looks like ([] already included)
-             * ```
-             * [?subject <predicate>] ?cv{id} .
-             * BIND(
-             *      IF(?cv{id} = value[0], 0, IF(?cv{id} = value[1], 1, ..., -1)) AS ?c{id}
-             * )
-             * ```
-             */
-            this.query = "?cv${id} .\n$filter -1${")".repeat(this.values.size)} AS ?$identifier)"
+            this.query = "?c${id}"
         }
 
         constructor(value: Term): super(
@@ -165,6 +161,10 @@ class Shape private constructor(
             var result = values.hashCode()
             result = 31 * result + (id ?: 0)
             return result
+        }
+
+        override fun encode(data: Term): String {
+            return values.indexOf(data).toString()
         }
 
         override fun decode(data: List<String>): List<Term> {
@@ -201,6 +201,11 @@ class Shape private constructor(
             return result
         }
 
+        override fun encode(data: Term): String {
+            // TODO: support for other datatypes, such as dates, and process the value as such
+            return data.value
+        }
+
         override fun decode(data: List<String>): List<Term> {
             // TODO: use the type to know what exact conversion needs to take place
             return data.map { it.toFloat().asLiteral() }
@@ -215,7 +220,15 @@ class Shape private constructor(
             build: BuildScope.() -> Shape
         ): Shape = BuildScope(typeIdentifier = ClassProperty(value = type)).build()
 
-        fun Binding.id() = LocalDateTime.parse(get(BINDING_IDENTIFIER)!!.value).toEpochMilli()
+        fun Binding.id(): Long {
+            return try {
+                // checking for either timezone aware strings...
+                Instant.parse(get(BINDING_IDENTIFIER)!!.value).toEpochMilliseconds()
+            } catch (e: Throwable) {
+                // or otherwise falling back to local date time strings
+                LocalDateTime.parse(get(BINDING_IDENTIFIER)!!.value).toEpochMilli()
+            }
+        }
 
         private fun LocalDateTime.toEpochMilli(): Long {
             return this.toInstant(TimeZone.of("UTC")).toEpochMilliseconds()
@@ -293,7 +306,7 @@ class Shape private constructor(
     }
 
     fun encode(result: Binding): String {
-        return "${result.id()}:" + variables.joinToString(";") { result[it.second.identifier!!]!!.value } + ';'
+        return "${result.id()}:" + variables.joinToString(";") { it.second.encode(result[it.second.identifier!!]!!) } + ';'
     }
 
     fun decode(

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Shape.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Shape.kt
@@ -221,12 +221,13 @@ class Shape private constructor(
         ): Shape = BuildScope(typeIdentifier = ClassProperty(value = type)).build()
 
         fun Binding.id(): Long {
+            val value = get(BINDING_IDENTIFIER)!!.value
             return try {
                 // checking for either timezone aware strings...
-                Instant.parse(get(BINDING_IDENTIFIER)!!.value).toEpochMilliseconds()
+                Instant.parse(value).toEpochMilliseconds()
             } catch (e: Throwable) {
                 // or otherwise falling back to local date time strings
-                LocalDateTime.parse(get(BINDING_IDENTIFIER)!!.value).toEpochMilli()
+                LocalDateTime.parse(value).toEpochMilli()
             }
         }
 
@@ -338,7 +339,7 @@ class Shape private constructor(
             }
             if (!relevant) return
             // processing the data & sending it through
-            data.decode(publisher.context, constraints, j++).forEach { emit(it) }
+            data.decode(publisher.context, j++).forEach { emit(it) }
         }
         while (iter.hasNext()) {
             when (val c = iter.next()) {
@@ -375,7 +376,6 @@ class Shape private constructor(
      */
     private fun List<String>.decode(
         context: RDFBuilder.Context,
-        constraints: Map<NamedNodeTerm, Iterable<NamedNodeTerm>>,
         id: Int
     ) = buildTriples(context) {
         val subject = with (context) { "Sample_$id".absolutePath }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
@@ -39,4 +39,6 @@ expect class StreamingResource(): TripleProvider {
 
     fun add(stream: InputStream<Triple>)
 
+    fun stop()
+
 }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
@@ -1,5 +1,8 @@
 package be.ugent.idlab.predict.ldests.rdf
 
+import be.ugent.idlab.predict.ldests.util.InputStream
+
+
 // represents all supported possible ways of obtaining triples (data)
 // includes local files and remote
 expect sealed interface TripleProvider
@@ -29,5 +32,11 @@ class RemoteResource private constructor(
         fun from(url: String) = RemoteResource(url = url)
 
     }
+
+}
+
+expect class StreamingResource(): TripleProvider {
+
+    fun add(stream: InputStream<Triple>)
 
 }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
@@ -7,6 +7,11 @@ expect interface Stream
 expect open class InputStream<T>: Stream
 
 /**
+ * Creates a single-entry stream of the provided value, useful if "slow" data insertions are happening
+ */
+expect fun <T> T.streamify(): InputStream<T>
+
+/**
  * Suspends until the stream finished
  */
 expect suspend fun Stream.join()

--- a/shared/src/jsMain/js/package.json
+++ b/shared/src/jsMain/js/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "src/main.js",
-  "lsd:module": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/shared/src/jsMain/js/package.json
+++ b/shared/src/jsMain/js/package.json
@@ -2,7 +2,8 @@
   "name": "base",
   "version": "1.0.0",
   "description": "",
-  "main": "main.js",
+  "main": "src/main.js",
+  "lsd:module": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/shared/src/jsMain/js/package.json
+++ b/shared/src/jsMain/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "base",
+  "name": "ldests_compat",
   "version": "1.0.0",
   "description": "",
   "main": "src/main.js",

--- a/shared/src/jsMain/js/src/main.js
+++ b/shared/src/jsMain/js/src/main.js
@@ -1,3 +1,6 @@
+const _engine = require("../lib/incremunica/engines/query-sparql-incremental/lib/QueryEngine.js");
+const _store = require("../lib/incremunica/packages/incremental-rdf-streaming-store/lib/StreamingStore.js");
+
 // function used to iterate over an AsyncIterator
 async function * asyncIteratorToGenerator(source) {
    source.read();
@@ -14,4 +17,6 @@ async function * asyncIteratorToGenerator(source) {
    }
 }
 
-exports.asyncIteratorToGenerator = asyncIteratorToGenerator
+exports.asyncIteratorToGenerator = asyncIteratorToGenerator;
+exports.QueryEngine = _engine.QueryEngine;
+exports.StreamingStore = _store.StreamingStore;

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/extra/Util.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/extra/Util.kt
@@ -1,4 +1,4 @@
-@file:JsModule("base")
+@file:JsModule("ldests_compat")
 
 package be.ugent.idlab.predict.ldests.lib.extra
 

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/node/NodeStream.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/node/NodeStream.kt
@@ -20,6 +20,9 @@ open external class ReadableNodeStream<T>(
 
     open fun push(data: T?)
 
+    @JsName("_read")
+    open fun read()
+
     override fun on(event: String, callback: (data: dynamic) -> Unit): ReadableNodeStream<T>
 
     override fun destroy(error: Error?)

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/Incremunica.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/Incremunica.kt
@@ -1,4 +1,4 @@
-@file:JsModule("base")
+@file:JsModule("ldests_compat")
 
 package be.ugent.idlab.predict.ldests.lib.rdf
 

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/Incremunica.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/Incremunica.kt
@@ -1,0 +1,13 @@
+@file:JsModule("@comunica/query-sparql-incremental")
+
+package be.ugent.idlab.predict.ldests.lib.rdf
+
+import kotlin.js.Promise
+
+@JsName("QueryEngine")
+external class IncremunicaQueryEngine {
+
+    @JsName("queryBindings")
+    fun query(query: String, options: dynamic) : Promise<ComunicaBindingStream>
+
+}

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/Incremunica.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/Incremunica.kt
@@ -1,4 +1,4 @@
-@file:JsModule("@comunica/query-sparql-incremental")
+@file:JsModule("base")
 
 package be.ugent.idlab.predict.ldests.lib.rdf
 

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/IncremunicaStreamingStore.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/IncremunicaStreamingStore.kt
@@ -1,12 +1,14 @@
-@file:JsModule("@comunica/incremental-rdf-streaming-store")
+@file:JsModule("base")
 
 package be.ugent.idlab.predict.ldests.lib.rdf
 
 import be.ugent.idlab.predict.ldests.lib.node.ReadableNodeStream
 
 @JsName("StreamingStore")
-external class StreamingStore() {
+external class IncremunicaStreamingStore() {
 
     fun import(stream: ReadableNodeStream<N3Triple>)
+
+    fun end()
 
 }

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/IncremunicaStreamingStore.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/IncremunicaStreamingStore.kt
@@ -1,4 +1,4 @@
-@file:JsModule("base")
+@file:JsModule("ldests_compat")
 
 package be.ugent.idlab.predict.ldests.lib.rdf
 

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/StreamingStore.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/lib/rdf/StreamingStore.kt
@@ -1,0 +1,12 @@
+@file:JsModule("@comunica/incremental-rdf-streaming-store")
+
+package be.ugent.idlab.predict.ldests.lib.rdf
+
+import be.ugent.idlab.predict.ldests.lib.node.ReadableNodeStream
+
+@JsName("StreamingStore")
+external class StreamingStore() {
+
+    fun import(stream: ReadableNodeStream<N3Triple>)
+
+}

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Query.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Query.kt
@@ -1,13 +1,10 @@
 package be.ugent.idlab.predict.ldests.rdf
 
 import be.ugent.idlab.predict.ldests.lib.node.finished
-import be.ugent.idlab.predict.ldests.lib.rdf.ComunicaBinding
-import be.ugent.idlab.predict.ldests.lib.rdf.ComunicaQueryEngine
-import be.ugent.idlab.predict.ldests.lib.rdf.N3Store
-import be.ugent.idlab.predict.ldests.lib.rdf.N3Triple
+import be.ugent.idlab.predict.ldests.lib.rdf.*
 import be.ugent.idlab.predict.ldests.util.InputStream
+import be.ugent.idlab.predict.ldests.util.dyn
 import be.ugent.idlab.predict.ldests.util.error
-import be.ugent.idlab.predict.ldests.util.log
 import be.ugent.idlab.predict.ldests.util.toStream
 import kotlinx.coroutines.await
 
@@ -29,29 +26,48 @@ actual suspend fun InputStream<N3Triple>.query(query: Query): InputStream<Bindin
         .toStream()
 }
 
-actual suspend fun TripleProvider.query(query: Query): InputStream<Binding>? {
-    val options: dynamic = Any()
-    options.sources = when (this) {
-        is LocalResource -> {
-            // using an intermediate actual N3 store generated from the file, which is used as a source for
-            //  the engine
-            val store = data.store
-            // keeping the store
-            arrayOf(store)
+actual suspend fun TripleProvider.query(query: Query): InputStream<Binding>? = when (this) {
+    is LocalResource -> {
+        // using an intermediate actual N3 store generated from the file, which is used as a source for
+        //  the engine
+        val store = data.store
+        // keeping the store
+        val options = dyn("sources" to arrayOf(store))
+        try {
+            ComunicaQueryEngine()
+                .query(query.sparql, options)
+                .await()
+                .toStream()
+        } catch (t: Throwable) {
+            error("Query failed: ${t.message}")
+            null
         }
-        is RemoteResource -> arrayOf(url)
-        else -> { throw RuntimeException("Unrecognized triple provider used in `query`!") }
     }
-    log("Applying querying (variables ${query.variables})")
-    return try {
-        ComunicaQueryEngine()
-            .query(query.sparql, options)
-            .await()
-            .toStream()
-    } catch (t: Throwable) {
-        error("Query failed: ${t.message}")
-        null
+    is RemoteResource -> {
+        val options = dyn("sources" to arrayOf(url))
+        try {
+            ComunicaQueryEngine()
+                .query(query.sparql, options)
+                .await()
+                .toStream()
+        } catch (t: Throwable) {
+            error("Query failed: ${t.message}")
+            null
+        }
     }
+    is StreamingResource -> {
+        val options = dyn("sources" to arrayOf(stream))
+        try {
+            IncremunicaQueryEngine()
+                .query(query.sparql, options)
+                .await()
+                .toStream()
+        } catch (t: Throwable) {
+            error("Query failed: ${t.message}")
+            null
+        }
+    }
+    else -> { throw RuntimeException("Unrecognized triple provider used in `query`!") }
 }
 
 actual operator fun ComunicaBinding.get(variable: String): Term? = get(variable)

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
@@ -1,8 +1,8 @@
 package be.ugent.idlab.predict.ldests.rdf
 
 import be.ugent.idlab.predict.ldests.lib.node.createReadFileStream
+import be.ugent.idlab.predict.ldests.lib.rdf.IncremunicaStreamingStore
 import be.ugent.idlab.predict.ldests.lib.rdf.N3Store
-import be.ugent.idlab.predict.ldests.lib.rdf.StreamingStore
 import be.ugent.idlab.predict.ldests.util.InputStream
 import be.ugent.idlab.predict.ldests.util.join
 import be.ugent.idlab.predict.ldests.util.log
@@ -37,10 +37,14 @@ actual class LocalResource private constructor(
 
 actual class StreamingResource actual constructor(): TripleProvider {
 
-    internal val stream = StreamingStore()
+    internal val stream = IncremunicaStreamingStore()
 
     actual fun add(stream: InputStream<Triple>) {
         this.stream.import(stream)
+    }
+
+    actual fun stop() {
+        stream.end()
     }
 
 }

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleProvider.kt
@@ -2,6 +2,8 @@ package be.ugent.idlab.predict.ldests.rdf
 
 import be.ugent.idlab.predict.ldests.lib.node.createReadFileStream
 import be.ugent.idlab.predict.ldests.lib.rdf.N3Store
+import be.ugent.idlab.predict.ldests.lib.rdf.StreamingStore
+import be.ugent.idlab.predict.ldests.util.InputStream
 import be.ugent.idlab.predict.ldests.util.join
 import be.ugent.idlab.predict.ldests.util.log
 import be.ugent.idlab.predict.ldests.util.mapToTriples
@@ -29,6 +31,16 @@ actual class LocalResource private constructor(
 
         actual fun wrap(buffer: TripleStore) = LocalResource(data = buffer)
 
+    }
+
+}
+
+actual class StreamingResource actual constructor(): TripleProvider {
+
+    internal val stream = StreamingStore()
+
+    actual fun add(stream: InputStream<Triple>) {
+        this.stream.import(stream)
     }
 
 }

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
@@ -29,6 +29,16 @@ actual suspend fun NodeStream.join() = suspendCancellableCoroutine { cont: Cance
     )
 }
 
+actual fun <T> T.streamify(): ReadableNodeStream<T> =
+    object: ReadableNodeStream<T>(
+        options = dyn("objectMode" to true)
+    ) {
+        override fun read() {
+            push(this@streamify)
+            destroy()
+        }
+    }
+
 actual fun fromFile(filepath: String): InputStream<String> {
     return createReadFileStream(filepath)
 }


### PR DESCRIPTION
Adds a new method for LDESTS to accept manual triple insertion. Currently, however, only after calling `flush` the inputs get processed (after which adding new triples is also no longer possible).
Also addresses #7 