### PR TITLE
Publisher subscription changes

### DIFF
--- a/exampleJsApp/index.ts
+++ b/exampleJsApp/index.ts
@@ -79,10 +79,10 @@ async function main() {
         .attachSolidPublisher("http://localhost:3000")
 //         .attachDebugPublisher()
         .create();
-    // await stream.append("../DAHCC-Data/dataset_participant_sample_accel_data.nt");
-    for await (const triple of generateRandomData(10)) {
-        stream.insert(triple);
-    }
+    await stream.append("../DAHCC-Data/dataset_participant_sample_accel_data.nt");
+    // for await (const triple of generateRandomData(10)) {
+    //     stream.insert(triple);
+    // }
     await stream.flush();
     const triples = new Array<Quad>();
     for await (const triple of generateRandomData(10)) {

--- a/exampleJsApp/index.ts
+++ b/exampleJsApp/index.ts
@@ -79,16 +79,16 @@ async function main() {
         .attachSolidPublisher("http://localhost:3000")
 //         .attachDebugPublisher()
         .create();
-    await stream.append("../DAHCC-Data/dataset_participant_sample_accel_data.nt");
-    // for await (const triple of generateRandomData(10)) {
-    //     stream.insert(triple);
-    // }
+    // await stream.append("../DAHCC-Data/dataset_participant_sample_accel_data.nt");
+    for await (const triple of generateRandomData(10)) {
+        stream.insert(triple);
+    }
     await stream.flush();
     const triples = new Array<Quad>();
     for await (const triple of generateRandomData(10)) {
         triples.push(triple)
     }
-    stream.insertBulk(triples);
+    await stream.insertStore(triples);
     await stream.flush();
     await stream.query(
         "http://localhost:3000",

--- a/jsLibrary/src/jsMain/kotlin/LDESTS.kt
+++ b/jsLibrary/src/jsMain/kotlin/LDESTS.kt
@@ -74,6 +74,12 @@ class LDESTSJS private constructor(
         parent.insert(data.asIterable())
     }
 
+    @Suppress("NON_EXPORTABLE_TYPE") // wrong in this case
+    @ExternalUse
+    fun insertStore(data: Array<N3Triple>) = promise {
+        parent.add(data.asIterable())
+    }
+
     /** Helper methods **/
 
     // dynamic constraints: `predicate`: ["value1", "value2", ...]

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/LDESTS.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/LDESTS.kt
@@ -39,12 +39,14 @@ class LDESTS private constructor(
     private var input = StreamingResource()
 
     suspend fun init() {
-        publishers.forEach { it.subscribe(scope, buffer) }
+        publishers.forEach { it.subscribe(buffer) }
         inputJob = scope.launch {
             // starting this in a separate job, as the insert blocks until finished, but input of type StreamingResource
             //  never finishes on its own, and this would then never return
             with (stream) { input.insert() }
         }
+        warn("Flushing publishers for the first time")
+        buffer.flush()
     }
 
     suspend fun append(filename: String) {
@@ -57,12 +59,25 @@ class LDESTS private constructor(
         }
     }
 
+    /**
+     * Inserts data as a streaming input source
+     */
     fun insert(data: Triple) {
         input.add(data.streamify())
     }
 
+    /**
+     * Inserts multiple data entries as a streaming input source
+     */
     fun insert(data: Iterable<Triple>) {
         input.add(data.streamify())
+    }
+
+    /**
+     * Inserts an entire chunk of data in one single go
+     */
+    suspend fun add(data: Iterable<Triple>) = with (stream) {
+        LocalResource.wrap(data.toStore()).insert()
     }
 
     suspend fun query(
@@ -81,6 +96,8 @@ class LDESTS private constructor(
         inputJob.join()
         warn("Flush: waiting for the stream to finish.")
         stream.flush()
+        warn("Flushing all attached publishers")
+        buffer.flush()
         // NOTE: it is not possible to call `job.join()` here when testing, it probably deadlocks the code due
         //  to the single threaded nature of JS (`flush` waiting on `join`, waiting in `globalscope` which waits on `flush` ?)
         warn("Flush: completed!")
@@ -156,7 +173,7 @@ class LDESTS private constructor(
                         return null
                     }
 
-                    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit) {
+                    override fun publish(path: String, data: RDFBuilder.() -> Unit) {
                         val str = Turtle(
                             context = context,
                             prefixes = Ontology.PREFIXES,

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/LDESTS.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/LDESTS.kt
@@ -156,14 +156,13 @@ class LDESTS private constructor(
                         return null
                     }
 
-                    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit): Boolean {
+                    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit) {
                         val str = Turtle(
                             context = context,
                             prefixes = Ontology.PREFIXES,
                             block = data
                         )
                         log("In debugger for `$path`:\n$str")
-                        return true
                     }
 
                 }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/MemoryPublisher.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/MemoryPublisher.kt
@@ -17,7 +17,7 @@ class MemoryPublisher: Publisher() {
         return null
     }
 
-    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit) {
+    override fun publish(path: String, data: RDFBuilder.() -> Unit) {
         buffer.insert(context = RDFBuilder.Context(path = path), block = data)
     }
 

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/MemoryPublisher.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/MemoryPublisher.kt
@@ -17,10 +17,8 @@ class MemoryPublisher: Publisher() {
         return null
     }
 
-    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit): Boolean {
+    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit) {
         buffer.insert(context = RDFBuilder.Context(path = path), block = data)
-        // always succeeds
-        return true
     }
 
 }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/PublishBuffer.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/PublishBuffer.kt
@@ -11,7 +11,7 @@ class PublishBuffer(
 
     private val publishers = mutableSetOf<Publisher>()
 
-    suspend fun emit(path: String, data: RDFBuilder.() -> Unit) {
+    fun emit(path: String, data: RDFBuilder.() -> Unit) {
         publishers.forEach { it.publish(path, data) }
     }
 
@@ -51,6 +51,10 @@ class PublishBuffer(
 
     fun onAttached(publishable: Publishable) {
         srcs.add(publishable)
+    }
+
+    suspend fun flush() {
+        publishers.forEach { it.flush() }
     }
 
 }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Publishable.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Publishable.kt
@@ -31,7 +31,7 @@ abstract class Publishable(
     // FIXME: this path MAY BE ignored in favour of `name` in some Builder contexts(?)! Can lead to bugs
     //  when using the `uri` generated from this context when the path is modified (e.g. .meta changes to
     //  a non-publishable but Builder.Element type)
-    protected suspend fun publish(path: String = name, block: RDFBuilder.() -> Unit) {
+    protected fun publish(path: String = name, block: RDFBuilder.() -> Unit) {
         buffer
             ?.emit(path = path, data = block)
             ?: run {

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Publisher.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Publisher.kt
@@ -2,10 +2,6 @@ package be.ugent.idlab.predict.ldests.core
 
 import be.ugent.idlab.predict.ldests.rdf.RDFBuilder
 import be.ugent.idlab.predict.ldests.rdf.TripleProvider
-import kotlinx.coroutines.*
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.set
 
 abstract class Publisher {
 
@@ -20,24 +16,23 @@ abstract class Publisher {
     abstract suspend fun fetch(path: String): TripleProvider?
 
     /**
-     * Publishes the data retrieved by executing the provided lambda. Returns `true` upon success (so memory can be
-     *  freed again)
-     * Expected path is the complete path after host, like `stream/fragment/` or `stream/fragment/resource`
+     * Publishes the data retrieved by executing the provided lambda.
+     * Expected path is the complete path after host, like `stream/` or `stream/fragment`
      */
-    abstract suspend fun publish(path: String, data: RDFBuilder.() -> Unit): Boolean
+    abstract suspend fun publish(path: String, data: RDFBuilder.() -> Unit)
 
     /**
-     * The publishable items this publisher is subscribed to
+     * The buffers this stream is currently subscribed to
      */
-    private val jobs = mutableMapOf<PublishBuffer, Job>()
+    private val bufs = mutableSetOf<PublishBuffer>()
 
     /**
      * Starts publishing everything the buffer receives. Keeps listening until `unsubscribe` with
      *  the same buffer is called or the program terminates
      */
-    suspend fun subscribe(scope: CoroutineScope, buffer: PublishBuffer) = with(buffer) {
-        subscribe(scope) { path, block -> publish(path, block) }?.let {
-            jobs[buffer] = it
+    suspend fun subscribe(buffer: PublishBuffer) = with(buffer) {
+        if (attach()) {
+            bufs.add(this)
         }
     }
 
@@ -45,20 +40,14 @@ abstract class Publisher {
      * Starts publishing everything created by the publishable item. Keeps listening until `unsubscribe` with
      *  the same publisher is called
      */
-    suspend fun unsubscribe(item: PublishBuffer) {
-        jobs[item]?.cancelAndJoin()
-        jobs.remove(item)
+    fun unsubscribe(buffer: PublishBuffer) = with(buffer) {
+        detach()
+        bufs.remove(this)
     }
 
-    suspend fun close() {
-        coroutineScope {
-            jobs.map { (item, job) ->
-                async {
-                    job.cancelAndJoin()
-                    jobs.remove(item)
-                }
-            }.awaitAll()
-        }
+    open fun close() {
+        val it = bufs.iterator()
+        while (it.hasNext()) { unsubscribe(it.next()) }
     }
 
 }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Publisher.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/core/Publisher.kt
@@ -19,7 +19,14 @@ abstract class Publisher {
      * Publishes the data retrieved by executing the provided lambda.
      * Expected path is the complete path after host, like `stream/` or `stream/fragment`
      */
-    abstract suspend fun publish(path: String, data: RDFBuilder.() -> Unit)
+    abstract fun publish(path: String, data: RDFBuilder.() -> Unit)
+
+    /**
+     * Publishes all data currently in cache, if any and if possible
+     */
+    open suspend fun flush() {
+        /* nothing to do by default */
+    }
 
     /**
      * The buffers this stream is currently subscribed to

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleStore.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/TripleStore.kt
@@ -24,3 +24,4 @@ expect class TripleStore() {
 operator fun TripleStore.Companion.invoke(path: String = "", block: RDFBuilder.() -> Unit) =
     TripleStore().apply { insert(context = RDFBuilder.Context(path = path), block) }
 
+fun Iterable<Triple>.toStore() = TripleStore().apply { this@toStore.forEach { add(it) } }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Turtle.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Turtle.kt
@@ -2,11 +2,11 @@ package be.ugent.idlab.predict.ldests.rdf
 
 expect class Turtle {
 
-    internal suspend fun finish(): String
+    internal fun finish(): String
 
     companion object {
 
-        suspend operator fun invoke(
+        operator fun invoke(
             context: RDFBuilder.Context,
             prefixes: Map<String, String> = mapOf(),
             block: RDFBuilder.() -> Unit

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/solid/SolidPublisher.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/solid/SolidPublisher.kt
@@ -18,8 +18,10 @@ class SolidPublisher(
         return connection.fromUrl("${context.path}/$path").read()
     }
 
-    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit): Boolean {
-        return connection.fromUrl("${context.path}/$path").write(block = data) in 200..299
+    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit) {
+        // TODO: keep the data callback somewhere "safe" so it can be reused if this call fails due to lacking
+        //  authentication or other (temporary) failures, while dropping the data upon success or irrecoverable failure
+        connection.fromUrl("${context.path}/$path").write(block = data)
     }
 
 }

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/solid/SolidPublisher.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/solid/SolidPublisher.kt
@@ -18,10 +18,14 @@ class SolidPublisher(
         return connection.fromUrl("${context.path}/$path").read()
     }
 
-    override suspend fun publish(path: String, data: RDFBuilder.() -> Unit) {
+    override fun publish(path: String, data: RDFBuilder.() -> Unit) {
         // TODO: keep the data callback somewhere "safe" so it can be reused if this call fails due to lacking
         //  authentication or other (temporary) failures, while dropping the data upon success or irrecoverable failure
         connection.fromUrl("${context.path}/$path").write(block = data)
+    }
+
+    override suspend fun flush() {
+        connection.flush()
     }
 
 }

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Turtle.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Turtle.kt
@@ -2,9 +2,6 @@ package be.ugent.idlab.predict.ldests.rdf
 
 import be.ugent.idlab.predict.ldests.lib.rdf.N3Writer
 import be.ugent.idlab.predict.ldests.util.dyn
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
 
 actual class Turtle private constructor(prefixes: Map<String, String>){
 
@@ -14,19 +11,21 @@ actual class Turtle private constructor(prefixes: Map<String, String>){
         N3Writer(dyn("prefixes" to p))
     }
 
-    internal actual suspend fun finish(): String = suspendCoroutine {
+    internal actual fun finish(): String {
+        var turtle: String = ""
         writer.finish { error, result ->
             if (error != null) {
-                it.resumeWithException(error)
+                throw error
             } else {
-                it.resume(result)
+                turtle = result
             }
         }
+        return turtle
     }
 
     actual companion object {
 
-        actual suspend operator fun invoke(
+        actual operator fun invoke(
             context: RDFBuilder.Context,
             prefixes: Map<String, String>,
             block: RDFBuilder.() -> Unit


### PR DESCRIPTION
Changed publisher subscription logic to use callbacks instead of coroutine jobs.
Removed the need for publishers to return publish status, as this is only relevant for publishers themselves