### PR TITLE
Small tweaks

### DIFF
--- a/exampleJsApp/index.ts
+++ b/exampleJsApp/index.ts
@@ -84,6 +84,12 @@ async function main() {
         stream.insert(triple);
     }
     await stream.flush();
+    const triples = new Array<Quad>();
+    for await (const triple of generateRandomData(10)) {
+        triples.push(triple)
+    }
+    stream.insertBulk(triples);
+    await stream.flush();
     await stream.query(
         "http://localhost:3000",
         (triple) => console.log(`Got object ${triple.object.value}`),

--- a/jsLibrary/src/jsMain/kotlin/LDESTS.kt
+++ b/jsLibrary/src/jsMain/kotlin/LDESTS.kt
@@ -69,6 +69,11 @@ class LDESTSJS private constructor(
         parent.insert(data)
     }
 
+    @ExternalUse
+    fun insertBulk(data: Array<N3Triple>) {
+        parent.insert(data.asIterable())
+    }
+
     /** Helper methods **/
 
     // dynamic constraints: `predicate`: ["value1", "value2", ...]

--- a/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
+++ b/shared/src/commonMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
@@ -9,7 +9,12 @@ expect open class InputStream<T>: Stream
 /**
  * Creates a single-entry stream of the provided value, useful if "slow" data insertions are happening
  */
-expect fun <T> T.streamify(): InputStream<T>
+expect fun Triple.streamify(): InputStream<Triple>
+
+/**
+ * Creates a multi-entry stream of the provided values, useful if "segmented" data insertions are happening
+ */
+expect fun Iterable<Triple>.streamify(): InputStream<Triple>
 
 /**
  * Suspends until the stream finished

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Query.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/rdf/Query.kt
@@ -6,6 +6,7 @@ import be.ugent.idlab.predict.ldests.util.InputStream
 import be.ugent.idlab.predict.ldests.util.dyn
 import be.ugent.idlab.predict.ldests.util.error
 import be.ugent.idlab.predict.ldests.util.toStream
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.await
 
 actual typealias Binding = ComunicaBinding
@@ -40,6 +41,9 @@ actual suspend fun TripleProvider.query(query: Query): InputStream<Binding>? = w
                 .toStream()
         } catch (t: Throwable) {
             error("Query failed: ${t.message}")
+            if (t is CancellationException) {
+                throw t
+            }
             null
         }
     }
@@ -52,6 +56,9 @@ actual suspend fun TripleProvider.query(query: Query): InputStream<Binding>? = w
                 .toStream()
         } catch (t: Throwable) {
             error("Query failed: ${t.message}")
+            if (t is CancellationException) {
+                throw t
+            }
             null
         }
     }
@@ -64,6 +71,9 @@ actual suspend fun TripleProvider.query(query: Query): InputStream<Binding>? = w
                 .toStream()
         } catch (t: Throwable) {
             error("Query failed: ${t.message}")
+            if (t is CancellationException) {
+                throw t
+            }
             null
         }
     }

--- a/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
+++ b/shared/src/jsMain/kotlin/be.ugent.idlab.predict.ldests/util/Stream.kt
@@ -1,6 +1,7 @@
 package be.ugent.idlab.predict.ldests.util
 
 import be.ugent.idlab.predict.ldests.lib.node.*
+import be.ugent.idlab.predict.ldests.lib.rdf.N3Triple
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
@@ -29,12 +30,22 @@ actual suspend fun NodeStream.join() = suspendCancellableCoroutine { cont: Cance
     )
 }
 
-actual fun <T> T.streamify(): ReadableNodeStream<T> =
-    object: ReadableNodeStream<T>(
+actual fun N3Triple.streamify(): ReadableNodeStream<N3Triple> =
+    object: ReadableNodeStream<N3Triple>(
         options = dyn("objectMode" to true)
     ) {
         override fun read() {
             push(this@streamify)
+            destroy()
+        }
+    }
+
+actual fun Iterable<N3Triple>.streamify(): ReadableNodeStream<N3Triple> =
+    object: ReadableNodeStream<N3Triple>(
+        options = dyn("objectMode" to true)
+    ) {
+        override fun read() {
+            this@streamify.forEach { triple -> push(triple) }
             destroy()
         }
     }


### PR DESCRIPTION
Added rubber-band solution to make it possible for manual triple insertion post-flush by resetting the input stream Added bulk-insertion method
Fixed cancellations causing unexpected query results by rethrowing the `CancellationException`